### PR TITLE
Update purchase history price

### DIFF
--- a/UnitTestLoginPage/DALPurchaseHistory.cs
+++ b/UnitTestLoginPage/DALPurchaseHistory.cs
@@ -25,7 +25,7 @@ namespace BookStoreLIB
             try
             {
                 string strSQL = @"
-            SELECT o.OrderID, b.Author, b.Title, o.OrderDate, oi.Quantity, (b.Price * oi.Quantity) AS TotalPrice
+            SELECT o.OrderID, b.Author, b.Title, o.OrderDate, oi.Quantity, SubTotal
             FROM Orders o
             INNER JOIN OrderItem oi ON o.OrderID = oi.OrderID
             INNER JOIN bookData b ON oi.ISBN = b.ISBN

--- a/UnitTestLoginPage/OrderItem.cs
+++ b/UnitTestLoginPage/OrderItem.cs
@@ -80,7 +80,7 @@ namespace BookStoreLIB
 
         public override string ToString()
         {
-            return $"<OrderItem ISBN='{BookID}' Quantity='{Quantity}' />";
+            return $"<OrderItem ISBN='{BookID}' Quantity='{Quantity}' SubTotal='{SubTotal}' />";
         }
     }
 }

--- a/UnitTestLoginPage/UnitTest1.cs
+++ b/UnitTestLoginPage/UnitTest1.cs
@@ -17,7 +17,7 @@ namespace BookStoreLIB
         public void TestPurchaseHistory()
         {
 
-            int testUserId = 8;
+            int testUserId = 1;
             PurchaseHistory purchaseHistory = new PurchaseHistory();
 
             DataSet result = purchaseHistory.GetPurchaseHistory(testUserId);
@@ -28,18 +28,18 @@ namespace BookStoreLIB
 
 
             DataRow firstRow = result.Tables["PurchaseHistory"].Rows[0];
-            Assert.AreEqual(15, firstRow["OrderID"]);
-            Assert.AreEqual("Jon Skeet", firstRow["Author"]);
-            Assert.AreEqual("NULLC# in Depth", firstRow["Title"]);
+            Assert.AreEqual(16, firstRow["OrderID"]);
+            Assert.AreEqual("Ian Palmer", firstRow["Author"]);
+            Assert.AreEqual("Essential Java 3D Fast : Developing 3D Graphics Applications in Java", firstRow["Title"]);
 
-            DateTime expectedDate = DateTime.Parse("10/17/2024 5:23:40 PM");
+            DateTime expectedDate = DateTime.Parse("10/29/2024 2:42:45 PM");
             DateTime actualDate = Convert.ToDateTime(firstRow["OrderDate"]);
 
             // Allow small differences if they exist (e.g., different DateTime.Kind or milliseconds)
             Assert.IsTrue(Math.Abs((expectedDate - actualDate).TotalSeconds) < 1, "OrderDate should be the same up to seconds precision.");
 
-            Assert.AreEqual(2, firstRow["Quantity"]);
-            Assert.AreEqual(82.44, Convert.ToDouble(firstRow["TotalPrice"]), 0.01);
+            Assert.AreEqual(1, firstRow["Quantity"]);
+            Assert.AreEqual(89.99, Convert.ToDouble(firstRow["TotalPrice"]), 0.01);
         }
 
 

--- a/UnitTestLoginPage/UnitTest1.cs
+++ b/UnitTestLoginPage/UnitTest1.cs
@@ -27,19 +27,19 @@ namespace BookStoreLIB
      Assert.IsNotNull(result, "Purchase history should not be null");
      Assert.IsTrue(result.Tables["PurchaseHistory"].Rows.Count > 0, "Purchase history should return at least one row");
 
-            DataRow firstRow = result.Tables["PurchaseHistory"].Rows[95];
-            Assert.AreEqual(96, firstRow["OrderID"]);
-            Assert.AreEqual("Roy Osherove", firstRow["Author"]);
-            Assert.AreEqual("The Art of Unit Testing: with examples in C#", firstRow["Title"]);
+            DataRow firstRow = result.Tables["PurchaseHistory"].Rows[0];
+            Assert.AreEqual(16, firstRow["OrderID"]);
+            Assert.AreEqual("Ian Palmer", firstRow["Author"]);
+            Assert.AreEqual("Essential Java 3D Fast : Developing 3D Graphics Applications in Java", firstRow["Title"]);
 
-            DateTime expectedDate = DateTime.Parse("11/30/2024 5:27:06 PM");
+            DateTime expectedDate = DateTime.Parse("10/29/2024 2:42:45 PM");
             DateTime actualDate = Convert.ToDateTime(firstRow["OrderDate"]);
     
                // Allow small differences if they exist (e.g., different DateTime.Kind or milliseconds)
      Assert.IsTrue(Math.Abs((expectedDate - actualDate).TotalSeconds) < 1, "OrderDate should be the same up to seconds precision.");
 
             Assert.AreEqual(1, firstRow["Quantity"]);
-            Assert.AreEqual(28.64, Convert.ToDouble(firstRow["SubTotal"]), 0.01);
+            Assert.AreEqual(89.99, Convert.ToDouble(firstRow["SubTotal"]), 0.01);
         }
 
         [TestMethod]

--- a/UnitTestLoginPage/UnitTest1.cs
+++ b/UnitTestLoginPage/UnitTest1.cs
@@ -27,19 +27,19 @@ namespace BookStoreLIB
             Assert.IsTrue(result.Tables["PurchaseHistory"].Rows.Count > 0, "Purchase history should return at least one row");
 
 
-            DataRow firstRow = result.Tables["PurchaseHistory"].Rows[0];
-            Assert.AreEqual(16, firstRow["OrderID"]);
-            Assert.AreEqual("Ian Palmer", firstRow["Author"]);
-            Assert.AreEqual("Essential Java 3D Fast : Developing 3D Graphics Applications in Java", firstRow["Title"]);
+            DataRow firstRow = result.Tables["PurchaseHistory"].Rows[95];
+            Assert.AreEqual(96, firstRow["OrderID"]);
+            Assert.AreEqual("Roy Osherove", firstRow["Author"]);
+            Assert.AreEqual("The Art of Unit Testing: with examples in C#", firstRow["Title"]);
 
-            DateTime expectedDate = DateTime.Parse("10/29/2024 2:42:45 PM");
+            DateTime expectedDate = DateTime.Parse("11/30/2024 5:27:06 PM");
             DateTime actualDate = Convert.ToDateTime(firstRow["OrderDate"]);
 
             // Allow small differences if they exist (e.g., different DateTime.Kind or milliseconds)
             Assert.IsTrue(Math.Abs((expectedDate - actualDate).TotalSeconds) < 1, "OrderDate should be the same up to seconds precision.");
 
             Assert.AreEqual(1, firstRow["Quantity"]);
-            Assert.AreEqual(89.99, Convert.ToDouble(firstRow["TotalPrice"]), 0.01);
+            Assert.AreEqual(28.64, Convert.ToDouble(firstRow["SubTotal"]), 0.01);
         }
 
 

--- a/rzBookstore/BQDialog.xaml
+++ b/rzBookstore/BQDialog.xaml
@@ -7,13 +7,21 @@
         mc:Ignorable="d"
         Title="Window1" Height="450" Width="800">
     <Grid>
-        <!-- DataGrid for Book Quotes -->
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        
+
         <DataGrid x:Name="bookquotedatagrid" 
               AutoGenerateColumns="False" 
               HorizontalAlignment="Stretch" 
               VerticalAlignment="Stretch"
-              Margin="10,10,10,50">
-            <!-- Adjust margin for button placement -->
+              Margin="10"
+              Grid.Row="0">
+     
+
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Quote ID" Binding="{Binding Quote_id}" Width="100"/>
                 <DataGridTextColumn Header="Book Title" Binding="{Binding Book_Title}" Width="150"/>
@@ -22,7 +30,7 @@
             </DataGrid.Columns>
         </DataGrid>
 
-    <StackPanel Margin="20" Height="160">
+    <StackPanel Orientation="Vertical" Margin="10" Grid.Row="1">
 
             <Label Content="Book:" />
             <TextBox x:Name="bookTextBox" Width="300" />
@@ -36,9 +44,9 @@
             <Button x:Name="updateButton" Content="Update" Click="UpdateButton_Click" Width="100" Margin="5" />
         </StackPanel>
 
-        <!-- Exit Button in the Bottom-Right Corner -->
+
     <Button x:Name="exitButton" Click="exitButton_Click" IsCancel="True"
             Content="Exit" MinWidth="80" Margin="10"
-            HorizontalAlignment="Right" VerticalAlignment="Bottom" />
+            HorizontalAlignment="Right" VerticalAlignment="Bottom" Grid.Row="1"/>
     </Grid>
 </Window>

--- a/rzBookstore/PHDialog.xaml
+++ b/rzBookstore/PHDialog.xaml
@@ -16,7 +16,7 @@
                 <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="200"/>
                 <DataGridTextColumn Header="Order Date" Binding="{Binding OrderDate}" Width="120"/>
                 <DataGridTextColumn Header="Quantity" Binding="{Binding Quantity}" Width="80"/>
-                <DataGridTextColumn Header="Total Price" Binding="{Binding TotalPrice}" Width="100"/>
+                <DataGridTextColumn Header="Total Price" Binding="{Binding SubTotal}" Width="100"/>
             </DataGrid.Columns>
         </DataGrid>
 


### PR DESCRIPTION
Purchase now shows discounted price for new orders.
Added new column 'subtotal' in orderItems table.
Changed stored procedure to also pull subtotal from main window.
Updated purchase history query to include subtotal rather than calculating total directly.
Fixed overlap issue in book quotes.
Updated purchase history test to reflect the subtotal change.